### PR TITLE
Fix compatibility with Thunderbird 139+

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,11 +1,32 @@
-browser.tabs.onCreated.addListener(async tab => {
-    browser.CustomFolderGroup.patch(tab.id);
+/* browser.tabs.onCreated.addListener(async tab => {
+    if (tab.type === "mail") {
+        browser.CustomFolderGroup.patch(tab.id);
+    }
 });
 
 // handle already open tabs.
 async function handleAlreadyOpenTabs() {
     let tabs = (await browser.tabs.query({})).filter(t => ["mail"].includes(t.type));
 
+    for (let tab of tabs) {
+        browser.CustomFolderGroup.patch(tab.id);
+    }
+}
+
+await handleAlreadyOpenTabs();
+
+*/
+
+browser.tabs.onCreated.addListener(async tab => {
+    console.log("group_favorite_folders: tab created, type:", tab.type, "id:", tab.id);
+    if (tab.type === "mail") {
+        browser.CustomFolderGroup.patch(tab.id);
+    }
+});
+
+async function handleAlreadyOpenTabs() {
+    let tabs = (await browser.tabs.query({})).filter(t => ["mail"].includes(t.type));
+    console.log("group_favorite_folders: open mail tabs:", tabs.map(t => t.id));
     for (let tab of tabs) {
         browser.CustomFolderGroup.patch(tab.id);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
         "gecko": {
             "id": "kickofitall@gmail.com",
             "strict_min_version": "136.0",
-            "strict_max_version": "138.*"
+            "strict_max_version": "*"
         }
     },
     "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
         "gecko": {
             "id": "kickofitall@gmail.com",
             "strict_min_version": "136.0",
-            "strict_max_version": "*"
+            "strict_max_version": "152.*"
         }
     },
     "icons": {


### PR DESCRIPTION
- Remove strict_max_version cap (was 138.*)
- Ignore non-mail tabs in onCreated listener
- Replace bare handleAlreadyOpenTabs() call with onInstalled to prevent re-patching on every extension reload, which was resetting all open tabs when the add-ons page was viewed